### PR TITLE
Support Bazel-5.0.0.

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -11,7 +11,7 @@ RUN apt-get update && \
     curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/bazel.gpg && \
     echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list && \
     apt-get update && \
-    apt-get install -y bazel bazel-1.0.0 bazel-4.0.0 bazel-4.2 && \
+    apt-get install -y bazel bazel-1.0.0 bazel-4.0.0 bazel-4.2 bazel-5.0.0 && \
     apt-get full-upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 USER user


### PR DESCRIPTION
- chore: Add the build-container action.
- Enable to build on the GitHub actions.
- feat(workflow): Use the 'Docker meta' action.
- feat(Dockerfile): Support bazel-5.0.0.
