### PR TITLE
Add `jobs.results` for getting matrix builds.

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -8,6 +8,21 @@ on:
       - 'main'
 
 jobs:
+  results:
+    # This job was inspired by https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [docker]
+    steps:
+      - run: exit 1
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
+
   docker:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
